### PR TITLE
Authorization ModelにてClient Discoveryをしないようにした

### DIFF
--- a/app/controllers/authorizations_controller.rb
+++ b/app/controllers/authorizations_controller.rb
@@ -10,8 +10,8 @@ class AuthorizationsController < ApplicationController
   def create
     id_token = authz.decode_id_token(id_token_fragment)
     id_token.verify!(
-      issuer: authz.issuer,
-      client_id: authz.identifier,
+      issuer: Authorization::ISSUER,
+      client_id: Authorization::IDENTIFIER,
       nonce: stored_nonce
     )
 


### PR DESCRIPTION
基本的にDiscoveryの機能は OPをDynamic Registrationする際に用いるということなので、Discoveryを使わない認証方法にした

https://github.com/nov/openid_connect/wiki/Client-Discovery